### PR TITLE
blame mojolicious for always changing things

### DIFF
--- a/lib/Mojolicious/Plugin/Web/Auth/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/Web/Auth/OAuth2.pm
@@ -70,6 +70,7 @@ sub _ua {
     unless ( $self->{_ua} ) {
         $self->{_ua} = Mojo::UserAgent->new();
         $self->{_ua}->transactor->name("Mojolicious::Plugin::Web::Auth/$Mojolicious::Plugin::Web::Auth::VERSION");
+        $self->{_ua}->proxy->detect; # supports ENV proxies
     }
 
     return $self->{_ua};


### PR DESCRIPTION
to fix

Mojo::UserAgent::name is DEPRECATED in favor of Mojo::UserAgent::Transactor::name at /usr/local/share/perl/5.10.1/Mojolicious/Plugin/Web/Auth/OAuth2.pm line 70.

Thanks
