### PR TITLE
add support, content type charset

### DIFF
--- a/lib/Mojolicious/Plugin/Web/Auth/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/Web/Auth/OAuth2.pm
@@ -87,7 +87,7 @@ sub _ua {
 
 sub _response_to_hash {
     my ( $self, $res ) = @_;
-    return ( $res->headers->content_type eq 'application/json' )
+    return ( $res->headers->content_type =~ /^application\/json[;]?/ )
         ? $res->json
         : Mojo::Parameters->new( $res->body )->to_hash;
 }


### PR DESCRIPTION
Google APIがレスポンスするcontent-typeにcharsetをつけるようになった模様です。
以前の実装だと、APIが`application/json; charset=utf-8`を返すと、`_response_to_hash`が以下のようなデータをつくってしまうようです。

```
$VAR1 = {
          '{
  "access_token" : "y（略）8",
  "token_type" : "Bearer",
  "expires_in" : 3600,
  "id_token" : "ey（略）Jh"
}' => ''
        };
```

この現象がいつ頃からか特定できていませんが、手元のサービスではSat Mar 15ごろからログにはエラーがでるようになったようです。

```
[Sat Mar 15 09:13:15 2014] [error] Cannot get a access_token at local/lib/perl5/Mojolicious/Plugin/Web/Auth/OAuth2.pm line 65.
```
