### PR TITLE
Update OAuth2.pm

### DIFF
--- a/lib/Mojolicious/Plugin/Web/Auth/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/Web/Auth/OAuth2.pm
@@ -24,6 +24,9 @@ sub auth_uri {
 sub callback {
     my ($self, $c, $callback) = @_;
 
+    if (my $error = $c->req->param('error')) {
+        return $callback->{on_error}->($error);
+    }
     if (my $error_description = $c->req->param('error_description')) {
         return $callback->{on_error}->($error_description);
     }


### PR DESCRIPTION
Call on_error callback if there is a 'error' query param. When a user cancel a Google+ auth request Google calls the redirect url with just 'error' query param. Right now the plugin code dies with an error "Cannot get a 'code' parameter".
