### PR TITLE
Add special headers for Fitbit.

### DIFF
--- a/lib/Mojolicious/Plugin/Web/Auth/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/Web/Auth/OAuth2.pm
@@ -57,8 +57,12 @@ sub callback {
         grant_type    => 'authorization_code',
     };
 
+    my $headers = defined $self->authorize_header && $self->moniker eq 'fitbit'
+        ? { 'Authorization' => $self->authorize_header . q{ } . delete $params->{client_secret} }
+        : { };
+
     my $tx = ( $Mojolicious::VERSION >= 3.85)
-        ? $self->_ua->post( $self->access_token_url => form => $params )
+        ? $self->_ua->post( $self->access_token_url => $headers => form => $params )
         : $self->_ua->post_form( $self->access_token_url => $params ); # Mojo::UserAgent::post_form is deprecated from version 3.85
 
     (my $res = $tx->success ) or do {


### PR DESCRIPTION
I don't like the idea of special-casing any sites, but this is one way to do it.  Another way would be to add an additional accessor which would allow the Plugin to define custom headers.

Here's what the Plugin class looks like:

https://github.com/oalders/mojolicious-plugin-web-auth-site-fitbit/blob/master/lib/Mojolicious/Plugin/Web/Auth/Site/Fitbit.pm

Do you have a preference here?  I'm opening this pull request mainly in order to get some feedback.

Fitbit docs are here: https://dev.fitbit.com/docs/oauth2/#access-token-request

Thanks!