### PR TITLE
Google - Support for offline mode

### DIFF
--- a/lib/Mojolicious/Plugin/Web/Auth/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/Web/Auth/OAuth2.pm
@@ -21,6 +21,7 @@ sub auth_uri {
     $url->query->param( redirect_uri  => $callback_uri );
     $url->query->param( scope         => $self->scope ) if ( defined $self->scope );
     $url->query->param( response_type => $self->response_type ) if ( defined $self->response_type );
+    $url->query->param( access_type   => $self->access_type ) if ( defined $self->access_type );
 
     if ( $self->validate_state ) {
         my $state = $self->state_generator ? $self->state_generator->() : _state_generator();
@@ -84,6 +85,10 @@ sub callback {
         push @args, $res->json;
     }
 
+    if (defined $dat->{refresh_token}) {
+        push @args, $dat->{refresh_token};
+    }
+
     return $callback->{on_finished}->(@args);
 }
 
@@ -117,7 +122,7 @@ sub _response_to_hash {
 
 # default state param generator copy from Plack::Session::State
 sub _state_generator {
-    Digest::SHA::sha1_hex(rand() . $$ . {} . time) 
+    Digest::SHA::sha1_hex(rand() . $$ . {} . time)
 }
 
 1;

--- a/lib/Mojolicious/Plugin/Web/Auth/Site/Google.pm
+++ b/lib/Mojolicious/Plugin/Web/Auth/Site/Google.pm
@@ -7,6 +7,7 @@ has scope            => 'https://www.googleapis.com/auth/plus.me'; # use Google+
 has authorize_url    => 'https://accounts.google.com/o/oauth2/auth?response_type=code';
 has access_token_url => 'https://accounts.google.com/o/oauth2/token';
 has user_info_url    => 'https://www.googleapis.com/plus/v1/people/me';
+has access_type      => 'offline'; # optional
 
 sub moniker {'google'};
 


### PR DESCRIPTION
When `access_type` is set to offline, Google returns a `refresh_token` with the response which can be used to validate that that the account is still enabled and that the access has not been revoked.

https://developers.google.com/identity/protocols/OAuth2WebServer#offline

The use case here is an internal company web app linked to Google Apps for auth - ensuring user accounts still exist etc.
