### PR TITLE
Pass along refresh_token on success, if it has been provided

### DIFF
--- a/lib/Mojolicious/Plugin/Web/Auth.pm
+++ b/lib/Mojolicious/Plugin/Web/Auth.pm
@@ -186,6 +186,8 @@ Facebook, Github, Google, Instagram, etc.
 
 =item access_token
 
+=item refresh_token ( if available )
+
 =item user_info ( enabled 'user_info' )
 
 =back

--- a/lib/Mojolicious/Plugin/Web/Auth/OAuth2.pm
+++ b/lib/Mojolicious/Plugin/Web/Auth/OAuth2.pm
@@ -72,6 +72,8 @@ sub callback {
 
     my $access_token = $dat->{access_token} or die "Cannot get a access_token";
     my @args = ($access_token);
+    push @args, $dat->{refresh_token} if $dat->{refresh_token};
+
     if ( $self->user_info ) {
         my $url = Mojo::URL->new( $self->user_info_url );
         $url->query->param( access_token => $access_token ) unless ( defined $self->authorize_header );


### PR DESCRIPTION
I'm working with the Reddit OAuth2 API and it allows you to request a `refresh_token` as part of the authorization process.  In order for this to work, it needs to be provided back on a successful authorization.

I couldn't see a clean way to do this with the current positional parameters.  Putting it last seems a bit weird, but maybe that's the better way to do it.  I don't think this code would break any of the current implementations since, if you were expecting a refresh token, your code is already broken.  If you weren't expecting it, then it wouldn't get added to the array.

To be clear, we could also create a `refresh_token` accessor and only add the param if the accessor exists, but that's also a little repetitive since the token should only be created if it has specifically been requested.

For reference:

https://github.com/reddit/reddit/wiki/OAuth2#authorization
https://tools.ietf.org/html/rfc6749

If you're inclined to accept this, please let me know about what changes you'd like to have made and I'll be happy to do my best.