### PR TITLE
Update default url's, scope and example to Google Sign-In

### DIFF
--- a/examples/AuthGoogle
+++ b/examples/AuthGoogle
@@ -60,7 +60,7 @@ __DATA__
 
 @@ index.html.ep
 % layout 'default';
-Hello <%= session('account_info')->{displayName} %>@<%= site %>
+Hello <%= session('account_info')->{name} %>@<%= site %>
 <form method="post" action="/logout">
 <button type="submit">Logout</button>
 </form>

--- a/lib/Mojolicious/Plugin/Web/Auth/Site/Google.pm
+++ b/lib/Mojolicious/Plugin/Web/Auth/Site/Google.pm
@@ -3,10 +3,10 @@ package Mojolicious::Plugin::Web::Auth::Site::Google;
 use Mojo::Base qw/Mojolicious::Plugin::Web::Auth::OAuth2/;
 
 has user_info        => 1;
-has scope            => 'https://www.googleapis.com/auth/plus.me'; # use Google+ API Service
-has authorize_url    => 'https://accounts.google.com/o/oauth2/auth?response_type=code';
-has access_token_url => 'https://accounts.google.com/o/oauth2/token';
-has user_info_url    => 'https://www.googleapis.com/plus/v1/people/me';
+has scope            => 'email profile';
+has authorize_url    => 'https://accounts.google.com/o/oauth2/v2/auth?response_type=code';
+has access_token_url => 'https://www.googleapis.com/oauth2/v4/token';
+has user_info_url    => 'https://www.googleapis.com/oauth2/v3/userinfo';
 has access_type      => 'offline';
 
 sub moniker {'google'};


### PR DESCRIPTION
[Google Sign-In](https://developers.google.com/identity/) (part of [Google Identity Platform](https://developers.google.com/identity/)) has different url's than the default in `Mojolicious::Plugin::Web::Auth::Site::Google`.

Current url's can be found using [The Discovery Document](https://developers.google.com/identity/protocols/OpenIDConnect#discovery).

Actual are:
```perl
has authorize_url    => 'https://accounts.google.com/o/oauth2/v2/auth?response_type=code';
has access_token_url => 'https://www.googleapis.com/oauth2/v4/token';
has user_info_url    => 'https://www.googleapis.com/oauth2/v3/userinfo';
```
Also the [scopes supported](https://developers.google.com/identity/protocols/googlescopes) are different. Basic profile info is `profile` and email is `email` so a good default would be `email profile`
The `profile` scope has different names of properties so I've updated also the [AuthGoogle](https://github.com/hayajo/Mojolicious-Plugin-Web-Auth/compare/master...pablrod:update/google_signin?expand=1#diff-53e950592169f7a685f98e3a5899075c) example.
