### PR TITLE
Fixes #36

### DIFF
--- a/lib/Mojolicious/Plugin/Web/Auth/Site/Github.pm
+++ b/lib/Mojolicious/Plugin/Web/Auth/Site/Github.pm
@@ -6,6 +6,7 @@ has user_info        => 1;
 has authorize_url    => 'https://github.com/login/oauth/authorize';
 has access_token_url => 'https://github.com/login/oauth/access_token';
 has user_info_url    => 'https://api.github.com/user';
+has authorize_header => 'token';
 
 sub moniker {'github'};
 


### PR DESCRIPTION
Fixes issue 36, from now on, github has deprecated access_token in URL.
